### PR TITLE
Rebase Docker container on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ WORKDIR /root
 RUN adduser nginx -S -u 666  -h /usr/share/nginx -H
 
 # Update & install deps
-RUN apk update && \
-    apk add \
+RUN apk --no-cache --update add \
+      ca-certificates \
       cmake \
       g++ \
       gcc \
@@ -35,7 +35,10 @@ RUN apk update && \
       git \
       go \
       gnupg \
+      icu \
+      icu-libs \
       make \
+      linux-headers \
       patch \
       pcre-dev \
       perl \
@@ -47,7 +50,6 @@ RUN apk update && \
 # Copy nginx source into container
 COPY src/nginx-$NGXVERSION.tar.gz nginx-$NGXVERSION.tar.gz
 COPY src/nginx.patch nginx.patch
-COPY src/boringssl.patch boringssl.patch
 
 # Import nginx team signing keys to verify the source code tarball (Cannot use HKPS yet with Alpine's version of gnupg)
 RUN gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $NGXSIGKEY
@@ -57,21 +59,21 @@ RUN wget "https://nginx.org/download/nginx-$NGXVERSION.tar.gz.asc" && \
     out=$(gpg --status-fd 1 --verify "nginx-$NGXVERSION.tar.gz.asc" 2>/dev/null) && \
     if echo "$out" | grep -qs "\[GNUPG:\] GOODSIG" && echo "$out" | grep -qs "\[GNUPG:\] VALIDSIG"; then echo "Good signature on nginx source file."; else echo "GPG VERIFICATION OF SOURCE CODE FAILED!" && echo "EXITING!" && exit 100; fi
 
-# Download PageSpeed
-RUN wget https://github.com/pagespeed/ngx_pagespeed/archive/$PSPDVER.tar.gz && \
-    tar -xzvf $PSPDVER.tar.gz && \
-    rm -v $PSPDVER.tar.gz && \
+# Download and build PageSpeed & PageSpeed Optimization Library (PSOL)
+## On Alpine we cannot just grab these prebuilt binaries as they expect us to be
+## running a system with glibc, so I have temporarily disabled the PageSpeed module for now.
+## To re-enable, make sure to re-add the following line:
+##     --add-module="$HOME/ngx_pagespeed-$PSPDVER" \
+## to the nginx configure arguments. Some patching will also be required.)
+##
+RUN echo "Downloading PageSpeed..." && wget -O - https://github.com/pagespeed/ngx_pagespeed/archive/$PSPDVER.tar.gz | tar -xz && \
     cd ngx_pagespeed-$PSPDVER/ && \
-    echo "Downloading PSOL binary from the URL specified in the PSOL_BINARY_URL file..." && \
-    PSOLURL=$(cat PSOL_BINARY_URL | grep https: | sed 's/$BIT_SIZE_NAME/x64/g') && \
-    wget $PSOLURL && \
-    tar -xzvf *.tar.gz && \
-    rm -v *.tar.gz
+    echo "Downloading PSOL..." && \
+    PSOLVER=$(basename $(cat PSOL_BINARY_URL) | cut -d"-" -f1) && \
+    wget -O - https://dl.google.com/dl/page-speed/psol/$PSOLVER-x64.tar.gz | tar -xz
 
 # Download and build BoringSSL
-# (Also patch it to report itself as OpenSSL 1.1.1 to trick Nginx into allowing us to use TLS v1.3)
 RUN git clone https://boringssl.googlesource.com/boringssl "$HOME/boringssl" && \
-    cd "$HOME/boringssl" && patch -p1 < "$HOME/boringssl.patch" && \
     mkdir "$HOME/boringssl/build/" && \
     cd "$HOME/boringssl/build/" && \
     cmake ../ && \
@@ -95,14 +97,21 @@ RUN tar -xzvf nginx-$NGXVERSION.tar.gz && \
 WORKDIR "/root/nginx-$NGXVERSION/"
 
 # Configure Nginx
-# Config options stolen from the current packaged version of nginx for Fedora 25.
-# cc-opt tweaked to use -fstack-protector-all, and -fPIE added to build position-independent.
-# Removed any of the modules that the Fedora team was building with "=dynamic" as they stop us being able
-# to build with -fPIE and require the less-hardened -fPIC option instead. (https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html)
-# Also removed the --with-debug flag (I don't need debug-level logging) and --with-ipv6 as the flag is now deprecated.
-# Removed all the mail modules as I have no intention of using this as a mailserver proxy.
-# The final tweaks are my --add-module lines at the bottom, and the --with-openssl
-# argument, to point the build to the OpenSSL Beta we downloaded earlier.
+## Config options mostly stolen from the Red Hat package of nginx for Fedora 25.
+##
+## cc-opt tweaked to use -fstack-protector-all, and -fPIE added to build position-independent.
+## Removed any of the modules that the Fedora team was building with "=dynamic" as they stop us being able
+## to build with -fPIE and require the less-hardened -fPIC option instead. (https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html)
+##
+## Also removed the --with-debug flag (I don't need debug-level logging) and --with-ipv6 as the flag is now deprecated.
+## Removed all the mail modules as I have no intention of using this as a mailserver proxy.
+## The final tweaks are my --add-module lines at the bottom, and the --with-openssl
+## argument, to point the build to the OpenSSL Beta we downloaded earlier.
+##
+## The Google PerfTools module has also been removed because the package is not available in Alpine:
+##     --with-google_perftools_module \
+## Re-add with the above line if the package becomes available, or you build it manually.
+##
 RUN ./configure \
         --prefix=/usr/share/nginx \
         --sbin-path=/usr/sbin/nginx \
@@ -140,12 +149,10 @@ RUN ./configure \
         --with-pcre-jit \
         --with-stream \
         --with-stream_ssl_module \
-        --with-google_perftools_module \
-        --with-cc-opt='-fPIE -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-all -I ../boringssl/.openssl/include/' \
-        --with-ld-opt='-Wl,-z,relro' \
+        --with-cc-opt="-fPIE -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-all -I ../boringssl/.openssl/include/" \
+        --with-ld-opt="-Wl,-z,relro" \
         --with-openssl="$HOME/boringssl" \
         --with-openssl-opt=enable-tls1_3 \
-        --add-module="$HOME/ngx_pagespeed-$PSPDVER" \
         --add-module="$HOME/ngx_headers_more" \
         --add-module="$HOME/ngx_devel_kit" \
         --add-module="$HOME/ngx_subs_filter" && \
@@ -157,12 +164,12 @@ RUN patch -p1 < "$HOME/nginx.patch" && \
     make install
 
 # Make sure the permissions are set correctly on our webroot, logdir and pidfile so that we can run the webserver as non-root.
-RUN chown -R nginx:nginx /usr/share/nginx && \
-    chown -R nginx:nginx /var/log/nginx && \
+RUN chown -R nginx /usr/share/nginx && \
+    chown -R nginx /var/log/nginx && \
     mkdir -p /var/lib/nginx/tmp && \
-    chown -R nginx:nginx /var/lib/nginx && \
+    chown -R nginx /var/lib/nginx && \
     touch /run/nginx.pid && \
-    chown -R nginx:nginx /run/nginx.pid
+    chown -R nginx /run/nginx.pid
 
 # Configure nginx to listen on 8080 instead of 80 (we can't bind to <1024 as non-root)
 RUN perl -pi -e 's,80;,8080;,' /etc/nginx/nginx.conf
@@ -173,7 +180,7 @@ RUN apk del \
       g++ \
       gcc \
       go \
-      make \
+      make
 
 # Print built version
 RUN nginx -V

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker run --cap-drop=all --name nginx -d -p 80:8080 boringnginx
 
 You can also automate the run command with a systemd service or something similar. This is probably how you will want to do it if you're customising this and using it to deploy a site in production. Creating a systemd service that calls the `docker run` command means you will end up with a webserver that basically operates as a normal installation of nginx would operate - but containerized as an all-in-one distribution.
 
-Obviously, this built container will not contain any of your site data, your `nginx.conf,` or your SSL keys. You probably want to look at the [Docker Volumes](https://docs.docker.com/engine/tutorials/dockervolumes/) documentation for information on giving the container access to these in a location on your host machine. This will probably be done by adding a few `-v` flags to the `docker run` examples above.
+Obviously, this built container will not contain any of your site data, your `nginx.conf,` or your SSL keys. You probably want to look at the [Docker Volumes](https://docs.docker.com/engine/tutorials/dockervolumes/) documentation for information on giving the container access to these in a location on your host machine. This will probably be done by adding a few `-v` flags to the `docker run` examples above. Please note that the user the nginx process runs under within the container will have the UID of `666` by default, and any files or directories you pass through to the container should be owned by this UID (it does not matter if there is no user with this UID on your host system).
 
 -----------------------------------------
 


### PR DESCRIPTION
Swap Docker container's CentOS base for Alpine.

Unfortunately requires the PageSpeed and Google PerfTools modules to be disabled until I can experiment further, but these are not strictly necessary for operation.