### PR TITLE
Build release boringssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN set -xe \
     && git clone --depth 1 https://boringssl.googlesource.com/boringssl "/usr/src/boringssl" \
     && mkdir "/usr/src/boringssl/build/" \
     && cd "/usr/src/boringssl/build/" \
-    && cmake ../ \
+    && cmake -DCMAKE_BUILD_TYPE=Release ../ \
     && make -j$(getconf _NPROCESSORS_ONLN) \
     && mkdir -p "/usr/src/boringssl/.openssl/lib" \
     && cd "/usr/src/boringssl/.openssl" \

--- a/Dockerfile-geoip
+++ b/Dockerfile-geoip
@@ -87,7 +87,7 @@ RUN set -xe \
     && git clone --depth 1 https://boringssl.googlesource.com/boringssl "/usr/src/boringssl" \
     && mkdir "/usr/src/boringssl/build/" \
     && cd "/usr/src/boringssl/build/" \
-    && cmake ../ \
+    && cmake -DCMAKE_BUILD_TYPE=Release ../ \
     && make -j$(getconf _NPROCESSORS_ONLN) \
     && mkdir -p "/usr/src/boringssl/.openssl/lib" \
     && cd "/usr/src/boringssl/.openssl" \


### PR DESCRIPTION
> Note that the default build flags in the top-level CMakeLists.txt are for debugging—optimisation isn't enabled. Pass -DCMAKE_BUILD_TYPE=Release to cmake to configure a release build.
>
> https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md#Building